### PR TITLE
添加手势启动APP功能（Add Launch App Configuration with gesture functionality）

### DIFF
--- a/src/ElectronBot.Braincase/App.xaml.cs
+++ b/src/ElectronBot.Braincase/App.xaml.cs
@@ -162,6 +162,9 @@ public partial class App : Application
             services.AddTransient<GamepadViewModel>();
             services.AddTransient<GamepadPage>();
 
+            services.AddTransient<GestureAppConfigPage>();
+            services.AddTransient<GestureAppConfigViewModel>();
+
             services.AddTransient<LongShadow>();
 
             services.AddTransient<HiddenTextView>();

--- a/src/ElectronBot.Braincase/Constants.cs
+++ b/src/ElectronBot.Braincase/Constants.cs
@@ -30,6 +30,8 @@ public class Constants
 
     public const string DefaultAudioNameKey = "DefaultAudioNameKey";
 
+    public const string CustomGestureAppConfigKey = "CustomGestureAppConfigKey";
+
     public const string DefaultCameraName = "USB";
 
     public const string MODEL_PATH = "ms-appx:///Assets//model.onnx";

--- a/src/ElectronBot.Braincase/Controls/GestureAppConfigItems.xaml
+++ b/src/ElectronBot.Braincase/Controls/GestureAppConfigItems.xaml
@@ -1,0 +1,96 @@
+<!--  Copyright (c) Microsoft Corporation and Contributors.  -->
+<!--  Licensed under the MIT License.  -->
+
+<ItemsControl
+    x:Class="ElectronBot.Braincase.Controls.GestureAppConfigItems"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:Name="GestureAppConfigTreesss"
+    mc:Ignorable="d">
+    <ItemsControl.Style>
+        <Style TargetType="ItemsControl">
+            <Setter Property="ItemsPanel">
+                <Setter.Value>
+                    <ItemsPanelTemplate>
+                        <StackPanel />
+                    </ItemsPanelTemplate>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="ItemTemplate">
+                <Setter.Value>
+                    <DataTemplate>
+                        <Border
+                            Margin="3"
+                            Padding="6"
+                            BorderBrush="#fff"
+                            BorderThickness="1"
+                            CornerRadius="5">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <StackPanel Margin="6" Orientation="Vertical">
+                                    <Grid Margin="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="70" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock x:Uid="GestureAppConfigTree_AppPath" VerticalAlignment="Center" />
+                                            <TextBlock Margin="3,0,0,0" VerticalAlignment="Center" Text=":" />
+                                        </StackPanel>
+                                        <TextBox
+                                            Grid.Column="1"
+                                            Width="Auto"
+                                            Height="30"
+                                            VerticalAlignment="Center"
+                                            Text="{Binding Path=AppPath, Mode=TwoWay}" />
+                                    </Grid>
+                                    <Grid Margin="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="70" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock x:Uid="GestureAppConfigTree_Text" VerticalAlignment="Center" />
+                                            <TextBlock Margin="3,0,0,0" VerticalAlignment="Center" Text=":" />
+                                        </StackPanel>
+                                        <TextBox
+                                            Grid.Column="1"
+                                            Width="Auto"
+                                            Height="30"
+                                            VerticalAlignment="Center"
+                                            Text="{Binding Path=SpeechText, Mode=TwoWay}" />
+                                    </Grid>
+                                    <Grid Margin="3">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="70" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock x:Uid="GestureAppConfigTree_GestureLabel" VerticalAlignment="Center" />
+                                            <TextBlock Margin="3,0,0,0" VerticalAlignment="Center" Text=":" />
+                                        </StackPanel>
+                                        <ComboBox
+                                            Grid.Column="1"
+                                            Width="Auto"
+                                            Height="30"
+                                            HorizontalAlignment="Stretch"
+                                            ItemsSource="{Binding GestureLabels, ElementName='GestureAppConfigTreesss'}"
+                                            SelectedValue="{Binding GestureLabel, Mode=TwoWay}" />
+                                    </Grid>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <Button x:Uid="GestureAppConfigTree_DeleteButton" VerticalAlignment="Center" Click="DeleteButton_Click" Tag="{Binding Path=Id}" />
+                                </StackPanel>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </ItemsControl.Style>
+</ItemsControl>

--- a/src/ElectronBot.Braincase/Controls/GestureAppConfigItems.xaml.cs
+++ b/src/ElectronBot.Braincase/Controls/GestureAppConfigItems.xaml.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Windows.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace ElectronBot.Braincase.Controls;
+public sealed partial class GestureAppConfigItems : ItemsControl
+{
+    public static readonly DependencyProperty GestureLabelsProperty = DependencyProperty.Register(
+        "GestureLabels",
+        typeof(List<string>),
+        typeof(GestureAppConfigItems),
+        new PropertyMetadata(null, GestureLabelsPropertyChanged)
+    );
+
+    private static void GestureLabelsPropertyChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+    {
+    }
+
+    public List<string> GestureLabels
+    {
+        get => (List<string>)GetValue(GestureLabelsProperty);
+        set => SetValue(GestureLabelsProperty, value);
+    }
+
+    #region
+    public static readonly DependencyProperty DeleteItemCommandProperty = DependencyProperty.Register(
+        "DeleteItemCommand",
+        typeof(ICommand),
+        typeof(GestureAppConfigItems),
+        new PropertyMetadata(null, DeleteItemCommandPropertyChanged)
+    );
+
+    private static void DeleteItemCommandPropertyChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+    {
+    }
+
+    public ICommand DeleteItemCommand
+    {
+        get => (ICommand)GetValue(DeleteItemCommandProperty);
+        set => SetValue(DeleteItemCommandProperty, value);
+    }
+
+    /// <summary>
+    /// fire event and command
+    /// </summary>
+    private void OnDeleteItem(string id)
+    {
+        if (DeleteItemCommand != null && DeleteItemCommand.CanExecute(id))
+        {
+            DeleteItemCommand.Execute(id);
+        }
+    }
+    #endregion
+
+    public GestureAppConfigItems()
+    {
+        InitializeComponent();
+    }
+
+    private void DeleteButton_Click(object sender, RoutedEventArgs e)
+    {
+        Button? button = sender as Button;
+
+        if (button != null && button.Tag is string id)
+        {
+            OnDeleteItem(id);
+        }
+    }
+}

--- a/src/ElectronBot.Braincase/ElectronBot.Braincase.csproj
+++ b/src/ElectronBot.Braincase/ElectronBot.Braincase.csproj
@@ -70,6 +70,7 @@
     <None Remove="Controls\ElectronBotModelLoader.xaml" />
     <None Remove="Controls\EmojisInfoContentDialog.xaml" />
     <None Remove="Controls\EmojisInfoPage.xaml" />
+    <None Remove="Controls\GestureAppConfigItems.xaml" />
     <None Remove="Controls\MarketplacePage.xaml" />
     <None Remove="Controls\RandomContentPage.xaml" />
     <None Remove="Controls\UploadEmojisPage.xaml" />
@@ -113,6 +114,7 @@
     <None Remove="VFS\SystemX64\mediapipe\modules\pose_landmark\tensors_to_pose_landmarks_and_segmentation.pbtxt" />
     <None Remove="Views\CameraEmojisPage.xaml" />
     <None Remove="Views\GamepadPage.xaml" />
+    <None Remove="Views\GestureAppConfigPage.xaml" />
     <None Remove="Views\GestureClassificationPage.xaml" />
     <None Remove="Views\GestureInteractionPage.xaml" />
     <None Remove="Views\ImageCropperPage.xaml" />
@@ -331,6 +333,12 @@
     <None Update="Assets\xbox-one-controller.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <Page Update="Controls\GestureAppConfigItems.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="Views\GestureAppConfigPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Update="Views\MoviePage.xaml">
       <XamlRuntime>$(DefaultXamlRuntime)</XamlRuntime>
     </Page>

--- a/src/ElectronBot.Braincase/Helpers/WindowHelper.cs
+++ b/src/ElectronBot.Braincase/Helpers/WindowHelper.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using ElectronBot.Braincase.Models;
+
+namespace ElectronBot.Braincase.Helpers;
+public class WindowHelper
+{
+    [DllImport("User32.dll")]
+    public static extern IntPtr GetForegroundWindow();     //获取活动窗口句柄
+
+    [DllImport("User32.dll", CharSet = CharSet.Auto)]
+    public static extern int GetWindowThreadProcessId(IntPtr hwnd, out int ID);   //获取线程ID
+
+    [DllImport("user32.dll ")]
+    private static extern bool SetForegroundWindow(IntPtr hWnd);
+
+    [DllImport("user32.dll")]
+    private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+    //根据任务栏应用程序显示的名称找窗口的名称
+    [DllImport("User32.dll", EntryPoint = "FindWindow")]
+    private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+    // 引入库
+    [DllImport("kernel32.dll")]
+    public static extern int WinExec(string programPath, int operType);
+
+    //[DllImport("User32")]
+    //public static extern bool OpenClipboard(IntPtr hWndNewOwner);
+
+    //[DllImport("User32")]
+    //public static extern bool CloseClipboard();
+
+    //[DllImport("User32")]
+    //public static extern bool EmptyClipboard();
+
+    //[DllImport("User32")]
+    //public static extern bool IsClipboardFormatAvailable(int format);
+
+    //[DllImport("User32")]
+    //public static extern IntPtr GetClipboardData(int uFormat);
+
+    //[DllImport("User32", CharSet = CharSet.Unicode)]
+    //public static extern IntPtr SetClipboardData(int uFormat, IntPtr hMem);
+
+    //[DllImport("user32.dll", SetLastError = true)]
+    //public static extern bool AddClipboardFormatListener(IntPtr hWnd);
+
+    //[DllImport("user32.dll", SetLastError = true)]
+    //public static extern bool RemoveClipboardFormatListener(IntPtr hWnd);
+
+    private static WindowHelper? _instance;
+    public static WindowHelper Instance => _instance ??= new WindowHelper();
+
+    /// <summary>
+    /// 获取当前活动窗口
+    /// </summary>
+    /// <returns></returns>
+    //public static WindowProcessInfo GetActiveWindowInfo()
+    //{
+    //    IntPtr hWnd = GetForegroundWindow();    //获取活动窗口句柄            
+    //    int calcTD = GetWindowThreadProcessId(hWnd, out int calcID); //calcID --> 进程ID  calcTD --> 线程ID
+    //    Process process = Process.GetProcessById(calcID);
+    //    WindowProcessInfo info = new()
+    //    {
+    //        ProcessName = process.ProcessName,
+    //        CalcID = calcID,
+    //        CalcTD = calcTD,
+    //        ProcessPath = process.MainModule.FileName
+    //    };
+    //    return info;
+    //}
+
+    private const int SW_RESTORE = 9;
+
+    /// <summary>
+    /// 开启应用
+    /// </summary>
+    /// <param name="appPath"></param>
+    public async Task StartProcess(string appPath)
+    {
+        Process[] exitProcesses = Process.GetProcessesByName(Path.GetFileNameWithoutExtension(appPath));
+        if (exitProcesses.Length > 0)
+        {
+        }
+        else
+        {
+            try
+            {
+                Process.Start(appPath);
+            }
+            catch
+            {
+                //创建启动对象
+                ProcessStartInfo startInfo = new ProcessStartInfo
+                {
+                    UseShellExecute = true,
+                    WorkingDirectory = Environment.CurrentDirectory,
+                    FileName = appPath,
+                    //设置启动动作,确保以管理员身份运行
+                    Verb = "runas"
+                };
+                try
+                {
+                    Process.Start(startInfo);
+                }
+                catch
+                {
+
+                }
+            }
+
+        }
+    }
+
+    /// <summary>
+    /// 将指定程序置顶
+    /// </summary>
+    /// <param name="appPath"></param>
+    /// <returns></returns>
+    public async Task ActiveProcess(string appPath)
+    {
+        Process[] exitProcesses = Process.GetProcessesByName(Path.GetFileNameWithoutExtension(appPath));
+        if (exitProcesses.Length > 0)
+        {
+            foreach (Process exitProcesse in exitProcesses)
+            {
+                // 将应用程序置顶
+                IntPtr hWnd = exitProcesse.MainWindowHandle;
+                if (hWnd != IntPtr.Zero)
+                {
+                    ShowWindow(hWnd, SW_RESTORE); //将窗口还原，如果不用此方法，缩小的窗口不能激活
+                    SetForegroundWindow(hWnd);// 将指定的窗口选中(激活)
+                }
+            }
+        }
+        else
+        {
+            _ = Process.Start(appPath);
+        }
+    }
+}

--- a/src/ElectronBot.Braincase/Models/GestureAppConfig.cs
+++ b/src/ElectronBot.Braincase/Models/GestureAppConfig.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ElectronBot.Braincase.Models;
+public class GestureAppConfig
+{
+    /// <summary>
+    /// 唯一标识
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 手势识别字段
+    /// </summary>
+    public string GestureLabel { get; set; } = string.Empty;
+
+    /// <summary>
+    /// 语音文本
+    /// </summary>
+    public string SpeechText { get; set; } = string.Empty;
+
+    /// <summary>
+    /// App启动路径
+    /// </summary>
+    public string AppPath { get; set; } = string.Empty;
+}
+
+public enum EventKind
+{
+    /// <summary>
+    /// 启动应用
+    /// </summary>
+    App,
+
+    /// <summary>
+    /// 键盘事件
+    /// </summary>
+    KeyOption,
+
+    /// <summary>
+    /// 返回上一层
+    /// </summary>
+    Back,
+}

--- a/src/ElectronBot.Braincase/Services/GestureApp/GestureAppService.cs
+++ b/src/ElectronBot.Braincase/Services/GestureApp/GestureAppService.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using ElectronBot.Braincase.Helpers;
+using ElectronBot.Braincase.Models;
+
+namespace ElectronBot.Braincase.Services;
+
+public class GestureAppService
+{
+    public List<GestureAppConfig>? _gestureAppConfigs = null;
+    private bool _inExecuting = false;
+    private Task? task_1 = null;
+
+    /// <summary>
+    /// 初始化
+    /// </summary>
+    /// <param name="gestureAppConfigs"></param>
+    public void Init(List<GestureAppConfig> gestureAppConfigs)
+    {
+        _gestureAppConfigs = gestureAppConfigs;
+    }
+
+    /// <summary>
+    /// 根据传入的手势识别结果执行相关操作
+    /// </summary>
+    /// <param name="e"></param>
+    /// <returns></returns>
+    public async Task Execute(string e)
+    {
+        if (_gestureAppConfigs != null)
+        {
+            foreach (var item in _gestureAppConfigs)
+            {
+                if (e == item.GestureLabel)
+                {
+                    _inExecuting = true;
+                    task_1 ??= Task.Run(async delegate
+                        {
+                            await Task.Delay(3000);
+                            _inExecuting = false;
+                            task_1 = null;
+                        });
+                    await WindowHelper.Instance.StartProcess(item.AppPath);
+                    if (!string.IsNullOrEmpty(item.SpeechText))
+                    {
+                        var appText = $"正在唤醒{item.SpeechText}";
+                        ToastHelper.SendToast(appText, TimeSpan.FromSeconds(2));
+                        await ElectronBotHelper.Instance.MediaPlayerPlaySoundByTtsAsync(appText, true);
+                    }
+                }
+            }
+        }
+    }
+
+    public bool GetInExecuting()
+    {
+        return _inExecuting;
+    }
+}

--- a/src/ElectronBot.Braincase/Services/PageService.cs
+++ b/src/ElectronBot.Braincase/Services/PageService.cs
@@ -28,6 +28,7 @@ public class PageService : IPageService
         Configure<GestureInteractionViewModel, GestureInteractionPage>();
         Configure<PoseRecognitionViewModel, PoseRecognitionPage>();
         Configure<MovieViewModel,MoviePage>();
+        Configure<GestureAppConfigViewModel, GestureAppConfigPage>();
     }
 
     public Type GetPageType(string key)

--- a/src/ElectronBot.Braincase/Strings/en-us/Resources.resw
+++ b/src/ElectronBot.Braincase/Strings/en-us/Resources.resw
@@ -741,4 +741,25 @@
   <data name="Shell_Movie.Content" xml:space="preserve">
     <value>Viewing Mode</value>
   </data>
+  <data name="GestureAppConfigTree_AppPath.Text" xml:space="preserve">
+    <value>App Path</value>
+  </data>
+  <data name="GestureAppConfigTree_DeleteButton.Content" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="GestureAppConfigTree_GestureLabel.Text" xml:space="preserve">
+    <value>Start Gesture</value>
+  </data>
+  <data name="GestureAppConfigTree_Text.Text" xml:space="preserve">
+    <value>Speech Text</value>
+  </data>
+  <data name="GestureAppConfig_Add.Content" xml:space="preserve">
+    <value>Add</value>
+  </data>
+  <data name="GestureAppConfig_Save.Content" xml:space="preserve">
+    <value>Save</value>
+  </data>
+  <data name="Shell_GestureAppConfig.Content" xml:space="preserve">
+    <value>Gesture App Config</value>
+  </data>
 </root>

--- a/src/ElectronBot.Braincase/Strings/zh-cn/Resources.resw
+++ b/src/ElectronBot.Braincase/Strings/zh-cn/Resources.resw
@@ -738,4 +738,25 @@
   <data name="Shell_Movie.Content" xml:space="preserve">
     <value>观影模式</value>
   </data>
+  <data name="Shell_GestureAppConfig.Content" xml:space="preserve">
+    <value>手势App配置</value>
+  </data>
+  <data name="GestureAppConfigTree_AppPath.Text" xml:space="preserve">
+    <value>APP路径</value>
+  </data>
+  <data name="GestureAppConfigTree_DeleteButton.Content" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="GestureAppConfigTree_GestureLabel.Text" xml:space="preserve">
+    <value>启动手势</value>
+  </data>
+  <data name="GestureAppConfigTree_Text.Text" xml:space="preserve">
+    <value>语音文本</value>
+  </data>
+  <data name="GestureAppConfig_Add.Content" xml:space="preserve">
+    <value>添加</value>
+  </data>
+  <data name="GestureAppConfig_Save.Content" xml:space="preserve">
+    <value>保存</value>
+  </data>
 </root>

--- a/src/ElectronBot.Braincase/ViewModels/GestureAppConfigViewModel.cs
+++ b/src/ElectronBot.Braincase/ViewModels/GestureAppConfigViewModel.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Text;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ElectronBot.Braincase.Contracts.Services;
+using ElectronBot.Braincase.Contracts.ViewModels;
+using ElectronBot.Braincase.Helpers;
+using ElectronBot.Braincase.Models;
+
+namespace ElectronBot.Braincase.ViewModels;
+
+public partial class GestureAppConfigViewModel : ObservableRecipient
+{
+    private readonly ILocalSettingsService _localSettingsService;
+
+    private ObservableCollection<GestureAppConfig> _gestureAppConfigs = new();
+    public ObservableCollection<GestureAppConfig> GestureAppConfigs
+    {
+        get => _gestureAppConfigs;
+        set => SetProperty(ref _gestureAppConfigs, value);
+    }
+
+    public List<string> GestureLabels { get; set; } = new()
+    {
+        Constants.Land,
+        Constants.Up,
+        Constants.Down,
+        Constants.Right,
+        Constants.Left,
+        Constants.Stop,
+        Constants.Forward,
+        Constants.Back,
+        Constants.FingerHeart,
+        Constants.ThirdFinger,
+    };
+
+    public GestureAppConfigViewModel(ILocalSettingsService localSettingsService)
+    {
+        _localSettingsService = localSettingsService;
+        Init();
+    }
+
+    public async void Init()
+    {
+        var gestureAppConfigs = (await _localSettingsService.ReadSettingAsync<List<GestureAppConfig>>
+                   (Constants.CustomGestureAppConfigKey)) ?? new List<GestureAppConfig>();
+
+        GestureAppConfigs = new ObservableCollection<GestureAppConfig>(gestureAppConfigs);
+    }
+
+
+    /// <summary>
+    /// 保存配置Command
+    /// </summary>
+    private ICommand _saveConfigCommand;
+    public ICommand SaveConfigCommand => _saveConfigCommand ??= new RelayCommand(SaveConfig);
+
+    /// <summary>
+    /// 保存配置
+    /// </summary>
+    public async void SaveConfig()
+    {
+       await _localSettingsService.SaveSettingAsync<List<GestureAppConfig>>(Constants.CustomGestureAppConfigKey, GestureAppConfigs.ToList());
+       Init();
+    }
+
+
+    /// <summary>
+    /// 删除配置项Command
+    /// </summary>
+    private ICommand _delConfigCommand;
+    public ICommand DelConfigCommand => _delConfigCommand ??= new RelayCommand<string>(DelConfig);
+
+    /// <summary>
+    /// 删除配置项
+    /// </summary>
+    /// <param name="id"></param>
+    public async void DelConfig(string id)
+    {
+        int index = -1;
+        for(int i = 0; i < GestureAppConfigs.Count; i++)
+        {
+            if (GestureAppConfigs[i].Id == id)
+            {
+                index = i; break;   
+            }
+        }
+
+        if (index >= 0)
+        {
+            GestureAppConfigs.RemoveAt(index);
+        }
+    }
+
+
+    /// <summary>
+    /// 添加配置项Command
+    /// </summary>
+    private ICommand _addConfigCommand;
+    public ICommand AddConfigCommand => _addConfigCommand ??= new RelayCommand(AddConfig);
+
+    /// <summary>
+    /// 删除配置项
+    /// </summary>
+    public async void AddConfig()
+    {
+        var gestureAppConfig = new GestureAppConfig()
+        {
+            Id = Guid.NewGuid().ToString(),
+        };
+        GestureAppConfigs.Add(gestureAppConfig);
+    }
+}

--- a/src/ElectronBot.Braincase/ViewModels/MainViewModel.cs
+++ b/src/ElectronBot.Braincase/ViewModels/MainViewModel.cs
@@ -69,6 +69,7 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware
 
     private readonly ElementTheme _elementTheme;
 
+    private GestureAppService _gestureAppService = new();
 
     private readonly IntPtr _hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
     public MainViewModel(
@@ -203,6 +204,10 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware
         {
             await InitializeScreenAsync();
         }
+
+        var gestureAppConfigs = (await _localSettingsService.ReadSettingAsync<List<GestureAppConfig>>
+                  (Constants.CustomGestureAppConfigKey)) ?? new List<GestureAppConfig>();
+        _gestureAppService.Init(gestureAppConfigs);
     }
 
     private async Task InitializeScreenAsync()
@@ -222,31 +227,36 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware
         {
             ResultLabel = e;
 
-            if (e == Constants.FingerHeart && _isBeginning == false)
+            //if (e == Constants.FingerHeart && _isBeginning == false)
+            //{
+            //    _isBeginning = true;
+
+            //    var config = (await _localSettingsService.ReadSettingAsync<CustomClockTitleConfig>
+            //    (Constants.CustomClockTitleConfigKey)) ?? new CustomClockTitleConfig();
+
+            //    var textList = config.AnswerText.Split(",").ToList();
+
+            //    var r = new Random().Next(textList.Count);
+
+            //    var text = textList[r];
+
+            //    ToastHelper.SendToast(text, TimeSpan.FromSeconds(2));
+
+            //    await ElectronBotHelper.Instance.MediaPlayerPlaySoundByTtsAsync(text, true);
+            //}
+            //else if (e == Constants.FingerHeart && _isBeginning == true)
+            //{
+            //    //当前处于启动状态
+            //    //不做处理
+            //}
+            //else if (e == Constants.Land && _isBeginning == true)
+            //{
+            //    _isBeginning = false;
+            //}
+
+            if (!_gestureAppService.GetInExecuting())
             {
-                _isBeginning = true;
-
-                var config = (await _localSettingsService.ReadSettingAsync<CustomClockTitleConfig>
-                (Constants.CustomClockTitleConfigKey)) ?? new CustomClockTitleConfig();
-
-                var textList = config.AnswerText.Split(",").ToList();
-
-                var r = new Random().Next(textList.Count);
-
-                var text = textList[r];
-
-                ToastHelper.SendToast(text, TimeSpan.FromSeconds(2));
-
-                await ElectronBotHelper.Instance.MediaPlayerPlaySoundByTtsAsync(text, true);
-            }
-            else if (e == Constants.FingerHeart && _isBeginning == true)
-            {
-                //当前处于启动状态
-                //不做处理
-            }
-            else if (e == Constants.Land && _isBeginning == true)
-            {
-                _isBeginning = false;
+                await _gestureAppService.Execute(ResultLabel);
             }
         });
     }

--- a/src/ElectronBot.Braincase/Views/GestureAppConfigPage.xaml
+++ b/src/ElectronBot.Braincase/Views/GestureAppConfigPage.xaml
@@ -1,0 +1,27 @@
+<!--  Copyright (c) Microsoft Corporation and Contributors.  -->
+<!--  Licensed under the MIT License.  -->
+
+<Page
+    x:Class="Views.GestureAppConfigPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:cusControl="using:ElectronBot.Braincase.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="using:Views"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+    mc:Ignorable="d">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="36" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackPanel Margin="3" Orientation="Horizontal">
+            <Button x:Uid="GestureAppConfig_Add" HorizontalAlignment="Left" Command="{x:Bind ViewModel.AddConfigCommand}" />
+            <Button x:Uid="GestureAppConfig_Save" Margin="7,0,0,0" HorizontalAlignment="Left" Command="{x:Bind ViewModel.SaveConfigCommand}" />
+        </StackPanel>
+        <ScrollViewer Grid.Row="1">
+            <cusControl:GestureAppConfigItems DeleteItemCommand="{x:Bind ViewModel.DelConfigCommand}" GestureLabels="{x:Bind ViewModel.GestureLabels}" ItemsSource="{x:Bind ViewModel.GestureAppConfigs, Mode=TwoWay}" />
+        </ScrollViewer>
+    </Grid>
+</Page>

--- a/src/ElectronBot.Braincase/Views/GestureAppConfigPage.xaml.cs
+++ b/src/ElectronBot.Braincase/Views/GestureAppConfigPage.xaml.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation and Contributors.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using ElectronBot.Braincase.ViewModels;
+using ElectronBot.Braincase;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Views;
+/// <summary>
+/// An empty page that can be used on its own or navigated to within a Frame.
+/// </summary>
+public sealed partial class GestureAppConfigPage : Page
+{
+    public GestureAppConfigViewModel ViewModel
+    {
+        get;
+    }
+
+    public GestureAppConfigPage()
+    {
+        ViewModel = App.GetService<GestureAppConfigViewModel>();
+
+        InitializeComponent();
+    }
+}

--- a/src/ElectronBot.Braincase/Views/ShellPage.xaml
+++ b/src/ElectronBot.Braincase/Views/ShellPage.xaml
@@ -12,10 +12,7 @@
 
 
     <Page.Resources>
-        <converters:BoolToVisibilityConverter
-            x:Name="ReverseBoolToVisibility"
-            FalseValue="Visible"
-            TrueValue="Collapsed" />
+        <converters:BoolToVisibilityConverter x:Name="ReverseBoolToVisibility" FalseValue="Visible" TrueValue="Collapsed" />
     </Page.Resources>
 
     <Grid>
@@ -25,11 +22,7 @@
             VerticalAlignment="Top"
             Canvas.ZIndex="1"
             IsHitTestVisible="True">
-            <Image
-                Width="16"
-                Height="16"
-                HorizontalAlignment="Left"
-                Source="/Assets/WindowIcon.ico" />
+            <Image Width="16" Height="16" HorizontalAlignment="Left" Source="/Assets/WindowIcon.ico" />
             <TextBlock
                 x:Name="AppTitleBarText"
                 Margin="28,0,0,0"
@@ -100,14 +93,16 @@
                         <FontIcon FontFamily="/Assets/Font/Segoe Fluent Icons.ttf#Segoe Fluent Icons" Glyph="&#xE7FC;" />
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+                <NavigationViewItem x:Uid="Shell_GestureAppConfig" helpers:NavigationHelper.NavigateTo="ElectronBot.Braincase.ViewModels.GestureAppConfigViewModel">
+                    <NavigationViewItem.Icon>
+                        <FontIcon FontFamily="/Assets/Font/Segoe Fluent Icons.ttf#Segoe Fluent Icons" Glyph="&#xE19D;" />
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
             </NavigationView.MenuItems>
             <NavigationView.HeaderTemplate>
                 <DataTemplate>
                     <Grid>
-                        <TextBlock
-                            FontFamily="/Assets/Font/SmileySans-Oblique.ttf#得意黑"
-                            Style="{ThemeResource TitleTextBlockStyle}"
-                            Text="{Binding}" />
+                        <TextBlock FontFamily="/Assets/Font/SmileySans-Oblique.ttf#得意黑" Style="{ThemeResource TitleTextBlockStyle}" Text="{Binding}" />
                     </Grid>
                 </DataTemplate>
             </NavigationView.HeaderTemplate>
@@ -116,10 +111,7 @@
                     <behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
                         <DataTemplate>
                             <Grid>
-                                <TextBlock
-                                    FontFamily="/Assets/Font/SmileySans-Oblique.ttf#得意黑"
-                                    Style="{ThemeResource TitleTextBlockStyle}"
-                                    Text="{Binding}" />
+                                <TextBlock FontFamily="/Assets/Font/SmileySans-Oblique.ttf#得意黑" Style="{ThemeResource TitleTextBlockStyle}" Text="{Binding}" />
                             </Grid>
                         </DataTemplate>
                     </behaviors:NavigationViewHeaderBehavior.DefaultHeaderTemplate>
@@ -141,20 +133,12 @@
                                 <ColumnDefinition Width="48" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Ellipse
-                                Grid.Column="0"
-                                Width="24"
-                                Height="24"
-                                HorizontalAlignment="Center">
+                            <Ellipse Grid.Column="0" Width="24" Height="24" HorizontalAlignment="Center">
                                 <Ellipse.Fill>
                                     <ImageBrush ImageSource="{x:Bind ViewModel.User.Photo, Mode=OneWay}" Stretch="UniformToFill" />
                                 </Ellipse.Fill>
                             </Ellipse>
-                            <TextBlock
-                                Grid.Column="1"
-                                VerticalAlignment="Center"
-                                Style="{ThemeResource BodyTextBlockStyle}"
-                                Text="{x:Bind ViewModel.User.Name, Mode=OneWay}" />
+                            <TextBlock Grid.Column="1" VerticalAlignment="Center" Style="{ThemeResource BodyTextBlockStyle}" Text="{x:Bind ViewModel.User.Name, Mode=OneWay}" />
                         </Grid>
                     </Button>
                     <Button
@@ -171,11 +155,7 @@
                                 <ColumnDefinition Width="48" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Ellipse
-                                Grid.Column="0"
-                                Width="24"
-                                Height="24"
-                                HorizontalAlignment="Center">
+                            <Ellipse Grid.Column="0" Width="24" Height="24" HorizontalAlignment="Center">
                                 <Ellipse.Fill>
                                     <ImageBrush ImageSource="/Assets/DefaultIcon.png" Stretch="UniformToFill" />
                                 </Ellipse.Fill>


### PR DESCRIPTION
中文备注：
添加（Views/GestureAppConfigPage.xaml）：手势启动APP配置页面
添加（ViewModels/GestureAppConfigViewModel.cs）：手势启动APP配置页面ViewModel 添加（Controls/GestureAppConfigItems.xaml）：手势启动APP配置的显示列表控件 添加（Services/GestureApp/GestureAppService.cs）：手势启动App服务 添加（Helpers/WindowHelper.cs）：启动Windows应用工具
修改（Constant.cs）：增加CustomGestureAppConfigKey关键字
修改（Strings/zh-cn | en-us/Resources.resw）
修改（Services/PageService.cs）：增加切换到“手势启动APP配置页面”需要的配置 修改（Views/ShellPage.xaml）：增加切换到“手势启动APP配置页面”需要的配置
修改（App.xaml.cs）：增加切换到“手势启动APP配置页面”需要的配置
修改（ViewModels/MainViewModel.cs）：增加在打开“手势识别”后，可以根据配置的手势启动对应的APP

English Remark：
Add（Views/GestureAppConfigPage.xaml）：Launch App Configuration with gesture Page Add（ViewModels/GestureAppConfigViewModel.cs）：Launch App Configuration with gesture Page ViewModel Add（Controls/GestureAppConfigItems.xaml）：Launch App Configuration with gesture List Control Add（Services/GestureApp/GestureAppService.cs）：Launch the App By Gesture Service Add（Helpers/WindowHelper.cs）：Launch the app of Windows Helper Update（Constant.cs）：Add CustomGestureAppConfigKey Key Update（Strings/zh-cn | en-us/Resources.resw）
Update（Services/PageService.cs）：Added configuration to switch to “Launch App Configuration with gesture Page” Update（Views/ShellPage.xaml）：Added configuration to switch to “Launch App Configuration with gesture Page” Update（App.xaml.cs）：Added configuration to switch to “Launch App Configuration with gesture Page” Update（ViewModels/MainViewModel.cs）：After turning on "Gesture Recognition", the corresponding APP can be launched according to the configured gesture